### PR TITLE
resolve several null pointer dereferences.

### DIFF
--- a/coders/msl.c
+++ b/coders/msl.c
@@ -552,7 +552,8 @@ static void MSLPushImage(MSLInfo *msl_info,Image *image)
   ssize_t
     n;
 
-  (void) LogMagickEvent(TraceEvent,GetMagickModule(),"%s",image->filename);
+  if (image != (Image *) NULL)
+    (void) LogMagickEvent(TraceEvent,GetMagickModule(),"%s",image->filename);
   assert(msl_info != (MSLInfo *) NULL);
   msl_info->n++;
   n=msl_info->n;

--- a/magick/constitute.c
+++ b/magick/constitute.c
@@ -1072,10 +1072,10 @@ MagickExport MagickBooleanType WriteImage(const ImageInfo *image_info,
   */
   assert(image_info != (ImageInfo *) NULL);
   assert(image_info->signature == MagickCoreSignature);
+  assert(image != (Image *) NULL);
   if (image->debug != MagickFalse)
     (void) LogMagickEvent(TraceEvent,GetMagickModule(),"%s",
       image_info->filename);
-  assert(image != (Image *) NULL);
   assert(image->signature == MagickCoreSignature);
   exception=(&image->exception);
   sans_exception=AcquireExceptionInfo();

--- a/magick/draw.c
+++ b/magick/draw.c
@@ -880,9 +880,9 @@ static PathInfo *ConvertPrimitiveToPath(
 */
 MagickExport DrawInfo *DestroyDrawInfo(DrawInfo *draw_info)
 {
+  assert(draw_info != (DrawInfo *) NULL);
   if (draw_info->debug != MagickFalse)
     (void) LogMagickEvent(TraceEvent,GetMagickModule(),"...");
-  assert(draw_info != (DrawInfo *) NULL);
   assert(draw_info->signature == MagickCoreSignature);
   if (draw_info->primitive != (char *) NULL)
     draw_info->primitive=DestroyString(draw_info->primitive);

--- a/magick/fx.c
+++ b/magick/fx.c
@@ -3972,9 +3972,9 @@ MagickExport MagickBooleanType PlasmaImage(Image *image,
   RandomInfo
     *random_info;
 
+  assert(image != (Image *) NULL);
   if (image->debug != MagickFalse)
     (void) LogMagickEvent(TraceEvent,GetMagickModule(),"...");
-  assert(image != (Image *) NULL);
   assert(image->signature == MagickCoreSignature);
   if (image->debug != MagickFalse)
     (void) LogMagickEvent(TraceEvent,GetMagickModule(),"...");
@@ -5036,7 +5036,6 @@ MagickExport Image *StereoAnaglyphImage(const Image *left_image,
   assert(right_image->signature == MagickCoreSignature);
   assert(exception != (ExceptionInfo *) NULL);
   assert(exception->signature == MagickCoreSignature);
-  assert(right_image != (const Image *) NULL);
   image=left_image;
   if ((left_image->columns != right_image->columns) ||
       (left_image->rows != right_image->rows))

--- a/magick/montage.c
+++ b/magick/montage.c
@@ -162,9 +162,9 @@ MagickExport MontageInfo *CloneMontageInfo(const ImageInfo *image_info,
 */
 MagickExport MontageInfo *DestroyMontageInfo(MontageInfo *montage_info)
 {
+  assert(montage_info != (MontageInfo *) NULL);
   if (montage_info->debug != MagickFalse)
     (void) LogMagickEvent(TraceEvent,GetMagickModule(),"...");
-  assert(montage_info != (MontageInfo *) NULL);
   assert(montage_info->signature == MagickCoreSignature);
   if (montage_info->geometry != (char *) NULL)
     montage_info->geometry=(char *)
@@ -410,10 +410,10 @@ MagickExport Image *MontageImageList(const ImageInfo *image_info,
   assert(exception->signature == MagickCoreSignature);
   number_images=GetImageListLength(images);
   master_list=ImageListToArray(images,exception);
-  image_list=master_list;
-  image=image_list[0];
   if (master_list == (Image **) NULL)
     ThrowImageException(ResourceLimitError,"MemoryAllocationFailed");
+  image_list=master_list;
+  image=image_list[0];
   thumbnail=NewImageList();
   for (i=0; i < (ssize_t) number_images; i++)
   {

--- a/magick/nt-base.c
+++ b/magick/nt-base.c
@@ -1748,11 +1748,8 @@ MagickPrivate DIR *NTOpenDirectory(const char *path)
         MaxTextExtent-wcslen(file_specification)-1) == (wchar_t *) NULL)
     return((DIR *) NULL);
   entry=(DIR *) AcquireCriticalMemory(sizeof(DIR));
-  if (entry != (DIR *) NULL)
-    {
-      entry->firsttime=TRUE;
-      entry->hSearch=FindFirstFileW(file_specification,&entry->Win32FindData);
-    }
+  entry->firsttime=TRUE;
+  entry->hSearch=FindFirstFileW(file_specification,&entry->Win32FindData);
   if (entry->hSearch == INVALID_HANDLE_VALUE)
     {
       if(wcsncat(file_specification,L"*.*",

--- a/wand/drawing-wand.c
+++ b/wand/drawing-wand.c
@@ -172,9 +172,9 @@ static int MVGPrintf(DrawingWand *wand,const char *format,...)
   size_t
     extent;
 
+  assert(wand != (DrawingWand *) NULL);
   if (wand->debug != MagickFalse)
     (void) LogMagickEvent(WandEvent,GetMagickModule(),"%s",format);
-  assert(wand != (DrawingWand *) NULL);
   assert(wand->signature == WandSignature);
   extent=20UL*MaxTextExtent;
   if (wand->mvg == (char *) NULL)
@@ -4540,9 +4540,9 @@ WandExport void DrawSetBorderColor(DrawingWand *wand,
 WandExport MagickBooleanType DrawSetClipPath(DrawingWand *wand,
   const char *clip_mask)
 {
+  assert(wand != (DrawingWand *) NULL);
   if (wand->debug != MagickFalse)
     (void) LogMagickEvent(WandEvent,GetMagickModule(),"%s",clip_mask);
-  assert(wand != (DrawingWand *) NULL);
   assert(wand->signature == WandSignature);
   assert(clip_mask != (const char *) NULL);
   if ((CurrentContext->clip_mask == (const char *) NULL) ||
@@ -4681,9 +4681,9 @@ WandExport void DrawSetClipUnits(DrawingWand *wand,
 WandExport MagickBooleanType DrawSetDensity(DrawingWand *wand,
   const char *density)
 {
+  assert(wand != (DrawingWand *) NULL);
   if (wand->debug != MagickFalse)
     (void) LogMagickEvent(WandEvent,GetMagickModule(),"%s",density);
-  assert(wand != (DrawingWand *) NULL);
   assert(wand->signature == MagickCoreSignature);
   assert(density != (const char *) NULL);
   if ((CurrentContext->density == (const char *) NULL) ||


### PR DESCRIPTION
found by cppcheck

[coders/msl.c:575] -> [coders/msl.c:555]: (warning) Either the condition 'image==(Image*)NULL' is redundant or there is possible null pointer dereference: image.
[magick/constitute.c:1078] -> [magick/constitute.c:1075]: (warning) Either the condition 'image!=(Image*)NULL' is redundant or there is possible null pointer dereference: image.
[magick/draw.c:885] -> [magick/draw.c:883]: (warning) Either the condition 'draw_info!=(DrawInfo*)NULL' is redundant or there is possible null pointer dereference: draw_info.
[magick/fx.c:3977] -> [magick/fx.c:3975]: (warning) Either the condition 'image!=(Image*)NULL' is redundant or there is possible null pointer dereference: image.
[magick/fx.c:5039] -> [magick/fx.c:5036]: (warning) Either the condition 'right_image!=(const Image*)NULL' is redundant or there is possible null pointer dereference: right_image.
[magick/montage.c:167] -> [magick/montage.c:165]: (warning) Either the condition 'montage_info!=(MontageInfo*)NULL' is redundant or there is possible null pointer dereference: montage_info.
[magick/montage.c:415] -> [magick/montage.c:414]: (warning) Either the condition 'master_list==(Image**)NULL' is redundant or there is possible null pointer dereference: image_list.
[magick/nt-base.c:1751] -> [magick/nt-base.c:1756]: (warning) Either the condition 'entry!=(DIR*)NULL' is redundant or there is possible null pointer dereference: entry.
[wand/drawing-wand.c:177] -> [wand/drawing-wand.c:175]: (warning) Either the condition 'wand!=(DrawingWand*)NULL' is redundant or there is possible null pointer dereference: wand.
[wand/drawing-wand.c:4545] -> [wand/drawing-wand.c:4543]: (warning) Either the condition 'wand!=(DrawingWand*)NULL' is redundant or there is possible null pointer dereference: wand.
[wand/drawing-wand.c:4686] -> [wand/drawing-wand.c:4684]: (warning) Either the condition 'wand!=(DrawingWand*)NULL' is redundant or there is possible null pointer dereference: wand.