### PR TITLE
Fix compiler warning about unused function.

### DIFF
--- a/coders/miff.c
+++ b/coders/miff.c
@@ -162,6 +162,7 @@ static MagickBooleanType IsMIFF(const unsigned char *magick,const size_t length)
 %
 */
 
+#if defined(MAGICKCORE_BZLIB_DELEGATE) || defined(MAGICKCORE_LZMA_DELEGATE) || defined(MAGICKCORE_ZLIB_DELEGATE)
 static void *AcquireCompressionMemory(void *context,const size_t items,
   const size_t size)
 {
@@ -176,6 +177,7 @@ static void *AcquireCompressionMemory(void *context,const size_t items,
     return((void *) NULL);
   return(AcquireMagickMemory(extent));
 }
+#endif
 
 #if defined(MAGICKCORE_BZLIB_DELEGATE)
 static void *AcquireBZIPMemory(void *context,int items,int size)


### PR DESCRIPTION
Note: this is a follow-up of https://github.com/ImageMagick/ImageMagick/pull/1253/

---

When neither of those compiler macros are available, the compiler is going to spit a warning about the unused static function.

```
coders/miff.c:164:14: warning: 'AcquireCompressionMemory' defined but not used [-Wunused-function]
 static void *AcquireCompressionMemory(void *context,const size_t items,
```

Fix this by making sure the static function is only defined when it's going to be used.