### PR TITLE
Fix for #23 - PSD profiles lost in layers

### DIFF
--- a/coders/psd.c
+++ b/coders/psd.c
@@ -2332,7 +2332,13 @@ static Image *ReadPSDImage(const ImageInfo *image_info,ExceptionInfo *exception)
     }
   if (profile != (StringInfo *) NULL)
     {
-      (void) SetImageProfile(image,GetStringInfoName(profile),profile);
+//      (void) SetImageProfile(image,GetStringInfoName(profile),profile);
+      // duplicate the profile to all layers
+      Image *onelayer = image;
+      while (onelayer && onelayer->next != image) {
+        (void) SetImageProfile(onelayer,GetStringInfoName(profile),profile);
+        onelayer = onelayer->next;
+      }
       profile=DestroyStringInfo(profile);
     }
   (void) CloseBlob(image);


### PR DESCRIPTION
This PR fixed issue #23 by not just setting the profile on the first image in the list, but on all images. That way the previous behavior is restored (while the memleaks that could occur when reading broken PSD files are still fixed).