### PR TITLE
Remove non-existing "-config" option from pkg-config

### DIFF
--- a/magick/MagickCore-config.in
+++ b/magick/MagickCore-config.in
@@ -38,7 +38,7 @@ while test $# -gt 0; do
       echo '@PACKAGE_VERSION@ Q@QUANTUM_DEPTH@ @MAGICK_HDRI@'
       ;;
     --cflags)
-      @PKG_CONFIG@ -config --cflags MagickCore
+      @PKG_CONFIG@ --cflags MagickCore
       ;;
     --cxxflags)
       @PKG_CONFIG@ --cflags MagickCore


### PR DESCRIPTION
This bug produces "Unknown option -config" error:

```
# MagickCore-config --cflags
Unknown option -config
```