### PR TITLE
Use user defined allocator/deallocator

### DIFF
--- a/magick/memory.c
+++ b/magick/memory.c
@@ -1051,7 +1051,7 @@ MagickExport void *RelinquishAlignedMemory(void *memory)
 #elif defined(MAGICKCORE_HAVE__ALIGNED_MALLOC)
   _aligned_free(memory);
 #else
-  free(*((void **) memory-1));
+  RelinquishMagickMemory(*((void **) memory-1));
 #endif
   return(NULL);
 }

--- a/magick/memory.c
+++ b/magick/memory.c
@@ -286,7 +286,7 @@ MagickExport void *AcquireAlignedMemory(const size_t count,const size_t quantum)
     extent=(size+alignment-1)+sizeof(void *);
     if (extent > size)
       {
-        p=malloc(extent);
+        p=AcquireMagickMemory(extent);
         if (p != NULL)
           {
             memory=(void *) AlignedExtent((size_t) p+sizeof(void *),alignment);

--- a/magick/opencl.c
+++ b/magick/opencl.c
@@ -1001,7 +1001,7 @@ cleanup:
   if (fileHandle != NULL)
     fclose(fileHandle);
   if (binaryFileName != NULL)
-    free(binaryFileName);
+    RelinquishMagickMemory(binaryFileName);
   if (binaryProgram != NULL)
     RelinquishMagickMemory(binaryProgram);
 
@@ -1771,8 +1771,8 @@ typedef ds_status (*ds_score_release)(void* score);
 static ds_status releaseDeviceResource(ds_device* device, ds_score_release sr) {
   ds_status status = DS_SUCCESS;
   if (device) {
-    if (device->oclDeviceName)      free(device->oclDeviceName);
-    if (device->oclDriverVersion)   free(device->oclDriverVersion);
+    if (device->oclDeviceName)      RelinquishMagickMemory(device->oclDeviceName);
+    if (device->oclDriverVersion)   RelinquishMagickMemory(device->oclDriverVersion);
     if (device->score)              status = sr(device->score);
   }
   return status;
@@ -1788,9 +1788,9 @@ static ds_status releaseDSProfile(ds_profile* profile, ds_score_release sr) {
         if (status != DS_SUCCESS)
           break;
       }
-      free(profile->devices);
+      RelinquishMagickMemory(profile->devices);
     }
-    free(profile);
+    RelinquishMagickMemory(profile);
   }
   return status;
 }
@@ -1901,16 +1901,16 @@ static ds_status initDSProfile(ds_profile** p, const char* version) {
   profile->version = version;
 
 cleanup:
-  if (platforms)  free(platforms);
-  if (devices)    free(devices);
+  if (platforms)  RelinquishMagickMemory(platforms);
+  if (devices)    RelinquishMagickMemory(devices);
   if (status == DS_SUCCESS) {
     *p = profile;
   }
   else {
     if (profile) {
       if (profile->devices)
-        free(profile->devices);
-      free(profile);
+        RelinquishMagickMemory(profile->devices);
+      RelinquishMagickMemory(profile);
     }
   }
   return status;
@@ -2063,7 +2063,7 @@ static ds_status writeProfileToFile(ds_profile* profile, ds_score_serializer ser
       status = serializer(profile->devices+i, &serializedScore, &serializedScoreSize);
       if (status == DS_SUCCESS && serializedScore!=NULL && serializedScoreSize > 0) {
         fwrite(serializedScore, sizeof(char), serializedScoreSize, profileFile);
-        free(serializedScore);
+        RelinquishMagickMemory(serializedScore);
       }
       fwrite(DS_TAG_SCORE_END, sizeof(char), strlen(DS_TAG_SCORE_END), profileFile);
       fwrite(DS_TAG_DEVICE_END, sizeof(char), strlen(DS_TAG_DEVICE_END), profileFile);
@@ -2111,7 +2111,7 @@ cleanup:
   if (input != NULL) fclose(input);
   if (status != DS_SUCCESS
       && binary != NULL) {
-      free(binary);
+      RelinquishMagickMemory(binary);
       *content = NULL;
       *contentSize = 0;
   }
@@ -2549,7 +2549,7 @@ ds_status AccelerateScoreDeserializer(ds_device* device, const unsigned char* se
     device->score = AcquireMagickMemory(sizeof(AccelerateScoreType));
     *((AccelerateScoreType*)device->score) = (AccelerateScoreType)
       strtod(s, (char **) NULL);
-    free(s);
+    RelinquishMagickMemory(s);
     return DS_SUCCESS;
   }
   else {

--- a/magick/opencl.c
+++ b/magick/opencl.c
@@ -1809,7 +1809,7 @@ static ds_status initDSProfile(ds_profile** p, const char* version) {
   if (p == NULL)
     return DS_INVALID_PROFILE;
 
-  profile = (ds_profile*)malloc(sizeof(ds_profile));
+  profile = (ds_profile*)AcquireMagickMemory(sizeof(ds_profile));
   if (profile == NULL)
     return DS_MEMORY_ERROR;
 
@@ -1817,7 +1817,7 @@ static ds_status initDSProfile(ds_profile** p, const char* version) {
 
   OpenCLLib->clGetPlatformIDs(0, NULL, &numPlatforms);
   if (numPlatforms > 0) {
-    platforms = (cl_platform_id*)malloc(numPlatforms*sizeof(cl_platform_id));
+    platforms = (cl_platform_id*)AcquireMagickMemory(numPlatforms*sizeof(cl_platform_id));
     if (platforms == NULL) {
       status = DS_MEMORY_ERROR;
       goto cleanup;
@@ -1832,7 +1832,7 @@ static ds_status initDSProfile(ds_profile** p, const char* version) {
 
   profile->numDevices = numDevices+1;     /* +1 to numDevices to include the native CPU */
 
-  profile->devices = (ds_device*)malloc(profile->numDevices*sizeof(ds_device));
+  profile->devices = (ds_device*)AcquireMagickMemory(profile->numDevices*sizeof(ds_device));
   if (profile->devices == NULL) {
     profile->numDevices = 0;
     status = DS_MEMORY_ERROR;
@@ -1841,7 +1841,7 @@ static ds_status initDSProfile(ds_profile** p, const char* version) {
   memset(profile->devices, 0, profile->numDevices*sizeof(ds_device));
 
   if (numDevices > 0) {
-    devices = (cl_device_id*)malloc(numDevices*sizeof(cl_device_id));
+    devices = (cl_device_id*)AcquireMagickMemory(numDevices*sizeof(cl_device_id));
     if (devices == NULL) {
       status = DS_MEMORY_ERROR;
       goto cleanup;
@@ -1874,13 +1874,13 @@ static ds_status initDSProfile(ds_profile** p, const char* version) {
 
           OpenCLLib->clGetDeviceInfo(profile->devices[next].oclDeviceID, CL_DEVICE_NAME
             , 0, NULL, &length);
-          profile->devices[next].oclDeviceName = (char*)malloc(sizeof(char)*length);
+          profile->devices[next].oclDeviceName = (char*)AcquireMagickMemory(sizeof(char)*length);
           OpenCLLib->clGetDeviceInfo(profile->devices[next].oclDeviceID, CL_DEVICE_NAME
             , length, profile->devices[next].oclDeviceName, NULL);
 
           OpenCLLib->clGetDeviceInfo(profile->devices[next].oclDeviceID, CL_DRIVER_VERSION
             , 0, NULL, &length);
-          profile->devices[next].oclDriverVersion = (char*)malloc(sizeof(char)*length);
+          profile->devices[next].oclDriverVersion = (char*)AcquireMagickMemory(sizeof(char)*length);
           OpenCLLib->clGetDeviceInfo(profile->devices[next].oclDeviceID, CL_DRIVER_VERSION
             , length, profile->devices[next].oclDriverVersion, NULL);
 
@@ -2093,7 +2093,7 @@ static ds_status readProFile(const char* fileName, char** content, size_t* conte
   fseek(input, 0L, SEEK_END);
   size = ftell(input);
   rewind(input);
-  binary = (char*)malloc(size);
+  binary = (char*)AcquireMagickMemory(size);
   if(binary == NULL) {
     status = DS_FILE_ERROR;
     goto cleanup;
@@ -2515,7 +2515,7 @@ static ds_status AcceleratePerfEvaluator(ds_device *device,
   /* end of microbenchmark */
 
   if (device->score == NULL)
-    device->score=malloc(sizeof(AccelerateScoreType));
+    device->score=AcquireMagickMemory(sizeof(AccelerateScoreType));
 
   if (status != MagickFalse)
     *(AccelerateScoreType*)device->score=readAccelerateTimer(&timer);
@@ -2529,7 +2529,7 @@ ds_status AccelerateScoreSerializer(ds_device* device, void** serializedScore, u
   if (device
      && device->score) {
     /* generate a string from the score */
-    char* s = (char*)malloc(sizeof(char)*256);
+    char* s = (char*)AcquireMagickMemory(sizeof(char)*256);
     sprintf(s,"%.4f",*((AccelerateScoreType*)device->score));
     *serializedScore = (void*)s;
     *serializedScoreSize = (unsigned int) strlen(s);
@@ -2543,10 +2543,10 @@ ds_status AccelerateScoreSerializer(ds_device* device, void** serializedScore, u
 ds_status AccelerateScoreDeserializer(ds_device* device, const unsigned char* serializedScore, unsigned int serializedScoreSize) {
   if (device) {
     /* convert the string back to an int */
-    char* s = (char*)malloc(serializedScoreSize+1);
+    char* s = (char*)AcquireMagickMemory(serializedScoreSize+1);
     memcpy(s, serializedScore, serializedScoreSize);
     s[serializedScoreSize] = (char)'\0';
-    device->score = malloc(sizeof(AccelerateScoreType));
+    device->score = AcquireMagickMemory(sizeof(AccelerateScoreType));
     *((AccelerateScoreType*)device->score) = (AccelerateScoreType)
       strtod(s, (char **) NULL);
     free(s);

--- a/magick/semaphore.c
+++ b/magick/semaphore.c
@@ -163,7 +163,7 @@ static void *AcquireSemaphoreMemory(const size_t count,const size_t quantum)
     extent=(size+alignment-1)+sizeof(void *);
     if (extent > size)
       {
-        p=malloc(extent);
+        p=AcquireMagickMemory(extent);
         if (p != NULL)
           {
             memory=(void *) AlignedExtent((size_t) p+sizeof(void *),alignment);

--- a/magick/semaphore.c
+++ b/magick/semaphore.c
@@ -184,7 +184,7 @@ static void *RelinquishSemaphoreMemory(void *memory)
 #elif defined(MAGICKCORE_HAVE__ALIGNED_MALLOC)
   _aligned_free(memory);
 #else
-  free(*((void **) memory-1));
+  RelinquishMagickMemory(*((void **) memory-1));
 #endif
   return(NULL);
 }


### PR DESCRIPTION
Now, I'm fighting to reduce memory usage in RMagick which is Ruby ImageMagick bridging.

To work Ruby's GC correctly, we need to know ImageMagick allocated memory size at runtime.
Because Ruby decides whether to run GC by current memory usage.
And the memory usage need to contain Ruby bridging (RMagick) and library (ImageMagick).

If it could notify total allocated memory size (RMagick + ImageMagick) to Ruby correctly,
Ruby's GC will work well and reduce application memory usage.

So, if ImageMagick has used Ruby's allocator configured by SetMagickMemoryMethods(),
Ruby can calculate the memory usage automatically.

This PR makes it possible to refer to a user defined allocator in where using `malloc`/`free` directly.

By this PR, it reduce RMagick memory usage from blue line to red line.

![memory_usage2](https://user-images.githubusercontent.com/199156/58807547-3b7d8480-8653-11e9-9f51-2756aff75458.png)

Related to https://github.com/rmagick/rmagick/pull/697