### PR TITLE
added Document JPG to policy pattern for web

### DIFF
--- a/www/security-policy.html
+++ b/www/security-policy.html
@@ -138,7 +138,7 @@ convert: no images defined `wizard.jpg'</code></pre>
 
 <pre class="highlight"><code>&lt;policy domain="delegate" rights="none" pattern="*" />
 &lt;policy domain="coder" rights="none" pattern="*" />
-&lt;policy domain="coder" rights="read | write" pattern="{GIF,JPEG,PNG,WEBP}" /></code></pre>
+&lt;policy domain="coder" rights="read | write" pattern="{GIF,JPEG,JPG,PNG,WEBP}" /></code></pre>
 
 <p>Here we disable just a few Postscript related formats:</p>
 <pre class="highlight"><code>&lt;policy domain="coder" rights="none" pattern="{EPS,PS2,PS3,PS,PDF,XPS}" /></code></pre>


### PR DESCRIPTION
Is it collect to add `JPG` for web-safe image types?  `*.jpg` is common extension for `JPEG` format.

my environment

```
identify -version
Version: ImageMagick 6.9.10-14 Q16 x86_64 2018-10-25 https://imagemagick.org
Copyright: © 1999-2018 ImageMagick Studio LLC
License: https://imagemagick.org/script/license.php
Features: Cipher DPC Modules
Delegates (built-in): bzlib freetype jng jp2 jpeg lcms ltdl lzma png tiff webp xml zlib
```

my tested policy.xml

```xml
<policymap>
  <policy domain="delegate" rights="none" pattern="*" />
  <policy domain="coder" rights="none" pattern="*" />
  <policy domain="coder" rights="read | write" pattern="{GIF,JPEG,PNG,WEBP}" />
</policymap>
```

```
$ identify cat.jpg
cat.jpg JPEG 1600x1106 1600x1106+0+0 8-bit sRGB 305839B 0.000u 0:00.000

$ convert cat.jpg hoge.jpeg
$ convert cat.jpg hoge.jpg
convert: attempt to perform an operation not allowed by the security policy `JPG' @ error/constitute.c/IsCoderAuthorized/408.
