### PR TITLE
Avoid freezing when svg file contains empty class name.

### DIFF
--- a/coders/svg.c
+++ b/coders/svg.c
@@ -1680,6 +1680,12 @@ static void SVGStartElement(void *context,const xmlChar *name,
                       value);
                     break;
                   }
+                else
+                  {
+                    /* empty class name */
+                    (void) FormatLocaleFile(svg_info->file,"class \"\"\n");
+                    break;
+                  }
               }
               break;
             }


### PR DESCRIPTION
When the svg file contains element with attribute class="" ie. empty string, the parser will end in endless loop which could led to DOS.