### PR TITLE
Fix bugs (ping/encoder/dispose_method/position) in webp coder

### DIFF
--- a/coders/webp.c
+++ b/coders/webp.c
@@ -232,10 +232,14 @@ static int FillBasicWEBPInfo(Image *image,const uint8_t *stream,size_t length,
 }
 
 static int ReadSingleWEBPImage(Image *image,const uint8_t *stream,
-  size_t length,WebPDecoderConfig *configure,ExceptionInfo *exception,MagickBooleanType is_first)
+  size_t length,WebPDecoderConfig *configure,ExceptionInfo *exception,
+  MagickBooleanType is_first)
 {
   int
     webp_status;
+
+  register unsigned char
+    *p;
 
   size_t
     canvas_width,
@@ -245,12 +249,7 @@ static int ReadSingleWEBPImage(Image *image,const uint8_t *stream,
 
   ssize_t
     x_offset,
-    y_offset;
-
-  register unsigned char
-    *p;
-
-  ssize_t
+    y_offset,
     y;
 
   WebPDecBuffer
@@ -260,32 +259,33 @@ static int ReadSingleWEBPImage(Image *image,const uint8_t *stream,
     status;
 
   if (is_first) {
-    canvas_width = image->columns;
-    canvas_height = image->rows;
-    x_offset = image->page.x;
-    y_offset = image->page.y;
-    image->page.x = 0;
-    image->page.y = 0;
+    canvas_width=image->columns;
+    canvas_height=image->rows;
+    x_offset=image->page.x;
+    y_offset=image->page.y;
+    image->page.x=0;
+    image->page.y=0;
   } else {
-    x_offset = 0;
-    y_offset = 0;
+    x_offset=0;
+    y_offset=0;
   }
-  webp_status = FillBasicWEBPInfo(image,stream,length,configure);
-  image_width = image->columns;
-  image_height = image->rows;
-  if (is_first) {
-    image->columns = canvas_width;
-    image->rows = canvas_height;
-  }
+  webp_status=FillBasicWEBPInfo(image,stream,length,configure);
+  image_width=image->columns;
+  image_height=image->rows;
+  if (is_first)
+    {
+      image->columns=canvas_width;
+      image->rows=canvas_height;
+    }
 
-  if(webp_status != VP8_STATUS_OK)
+  if (webp_status != VP8_STATUS_OK)
     return(webp_status);
 
   if (IsWEBPImageLossless(stream,length) != MagickFalse)
     image->quality=100;
 
   webp_status=WebPDecode(stream,length,configure);
-  if(webp_status != VP8_STATUS_OK)
+  if (webp_status != VP8_STATUS_OK)
     return(webp_status);
 
   p=(unsigned char *) webp_image->u.RGBA.rgba;
@@ -412,8 +412,8 @@ static int ReadAnimatedWEBPImage(const ImageInfo *image_info,Image *image,
   webp_status=0;
   original_image=image;
   webp_status=FillBasicWEBPInfo(image,stream,length,configure);
-  canvas_width = image->columns;
-  canvas_height = image->rows;
+  canvas_width=image->columns;
+  canvas_height=image->rows;
   data.bytes=stream;
   data.size=length;
   demux=WebPDemux(&data);
@@ -435,16 +435,15 @@ static int ReadAnimatedWEBPImage(const ImageInfo *image_info,Image *image,
         webp_status=ReadSingleWEBPImage(image,iter.fragment.bytes,
           iter.fragment.size,configure,exception,MagickTrue);
       }
-      if(webp_status != VP8_STATUS_OK)
+      if (webp_status != VP8_STATUS_OK)
         break;
 
-      image->page.width = canvas_width;
-      image->page.height = canvas_height;
+      image->page.width=canvas_width;
+      image->page.height=canvas_height;
       image->ticks_per_second=100;
       image->delay=iter.duration/10;
-      if (iter.dispose_method == WEBP_MUX_DISPOSE_BACKGROUND) {
-        image->dispose = BackgroundDispose;
-      }
+      if (iter.dispose_method == WEBP_MUX_DISPOSE_BACKGROUND)
+        image->dispose=BackgroundDispose;
       image_count++;
     } while (WebPDemuxNextFrame(&iter));
     WebPDemuxReleaseIterator(&iter);

--- a/coders/webp.c
+++ b/coders/webp.c
@@ -258,17 +258,20 @@ static int ReadSingleWEBPImage(Image *image,const uint8_t *stream,
   MagickBooleanType
     status;
 
-  if (is_first) {
-    canvas_width=image->columns;
-    canvas_height=image->rows;
-    x_offset=image->page.x;
-    y_offset=image->page.y;
-    image->page.x=0;
-    image->page.y=0;
-  } else {
-    x_offset=0;
-    y_offset=0;
-  }
+  if (is_first)
+    {
+      canvas_width=image->columns;
+      canvas_height=image->rows;
+      x_offset=image->page.x;
+      y_offset=image->page.y;
+      image->page.x=0;
+      image->page.y=0;
+    }
+  else
+    {
+      x_offset=0;
+      y_offset=0;
+    }
   webp_status=FillBasicWEBPInfo(image,stream,length,configure);
   image_width=image->columns;
   image_height=image->rows;
@@ -303,17 +306,20 @@ static int ReadSingleWEBPImage(Image *image,const uint8_t *stream,
     for (x=0; x < (ssize_t) image->columns; x++)
     {
       if ((x >= x_offset && x < x_offset + image_width) &&
-          (y >= y_offset && y < y_offset + image_height)) {
-        SetPixelRed(q,ScaleCharToQuantum(*p++));
-        SetPixelGreen(q,ScaleCharToQuantum(*p++));
-        SetPixelBlue(q,ScaleCharToQuantum(*p++));
-        SetPixelAlpha(q,ScaleCharToQuantum(*p++));
-      } else {
-        SetPixelRed(q,0);
-        SetPixelGreen(q,0);
-        SetPixelBlue(q,0);
-        SetPixelAlpha(q,0);
-      }
+          (y >= y_offset && y < y_offset + image_height))
+        {
+          SetPixelRed(q,ScaleCharToQuantum(*p++));
+          SetPixelGreen(q,ScaleCharToQuantum(*p++));
+          SetPixelBlue(q,ScaleCharToQuantum(*p++));
+          SetPixelAlpha(q,ScaleCharToQuantum(*p++));
+        }
+      else
+        {
+          SetPixelRed(q,0);
+          SetPixelGreen(q,0);
+          SetPixelBlue(q,0);
+          SetPixelAlpha(q,0);
+        }
       q++;
     }
     if (SyncAuthenticPixels(image,exception) == MagickFalse)
@@ -419,22 +425,25 @@ static int ReadAnimatedWEBPImage(const ImageInfo *image_info,Image *image,
   demux=WebPDemux(&data);
   if (WebPDemuxGetFrame(demux,1,&iter)) {
     do {
-      if (image_count != 0) {
-        AcquireNextImage(image_info,image);
-        if (GetNextImageInList(image) == (Image *) NULL)
-          break;
-        image=SyncNextImageInList(image);
-        CloneImageProperties(image, original_image);
-        image->page.x=iter.x_offset;
-        image->page.y=iter.y_offset;
-        webp_status=ReadSingleWEBPImage(image,iter.fragment.bytes,
-          iter.fragment.size,configure,exception,MagickFalse);
-      } else {
-        image->page.x=iter.x_offset;
-        image->page.y=iter.y_offset;
-        webp_status=ReadSingleWEBPImage(image,iter.fragment.bytes,
-          iter.fragment.size,configure,exception,MagickTrue);
-      }
+      if (image_count != 0)
+        {
+          AcquireNextImage(image_info,image);
+          if (GetNextImageInList(image) == (Image *) NULL)
+            break;
+          image=SyncNextImageInList(image);
+          CloneImageProperties(image, original_image);
+          image->page.x=iter.x_offset;
+          image->page.y=iter.y_offset;
+          webp_status=ReadSingleWEBPImage(image,iter.fragment.bytes,
+            iter.fragment.size,configure,exception,MagickFalse);
+        }
+      else
+        {
+          image->page.x=iter.x_offset;
+          image->page.y=iter.y_offset;
+          webp_status=ReadSingleWEBPImage(image,iter.fragment.bytes,
+            iter.fragment.size,configure,exception,MagickTrue);
+        }
       if (webp_status != VP8_STATUS_OK)
         break;
 


### PR DESCRIPTION
Hi.
I've found some bugs in the webp coder (both decoder & encoder).
Please refer to the below for more details.

1. "Image ping" cannot extract the number of scenes correctly. When I aim to get properties of an animated webp image via “MagickPingImageBlob” function, a wand object returned from the function doesn’t contain the exact number of scenes. (MagickGetNumberImages always returns 1). So, I checked the webp decoder part, and I found the decoder only loads entire image frames when the ping flag doesn’t set. Therefore, I suggest the decoder load full frames whether a given request is ping type or not.

2. Here, the current decoder assumes the first page doesn’t have positional information. The webp library correctly provides the size of virtual its virtual canvas by parsing headers; however, the current encoder doesn’t use it. Please check the attached webp file. if one tries to convert that webp file into gif file (“convert test.webp test.gif”) Each position of a frame in images is totally jumbled.

3. Also, the current decoder doesn’t reflect the dispose method of the original webp image correctly. So I suggest setting image->dispose by checking iter.dispose_method value.

4. There’s a bug in the encoding function (i.e., WriteWEBPImage). The function requires three arguments (image_info, image, exception); however, this function is called with two arguments (except exception).

Again, Thanks for your efforts to maintain ImageMagick library 👍 