### PR TITLE
Fix webp encoder to support animated webp images

### DIFF
--- a/coders/webp.c
+++ b/coders/webp.c
@@ -1039,7 +1039,7 @@ static MagickBooleanType WriteWEBPImage(const ImageInfo *image_info,
   WriteSingleWEBPImage(image_info,image,&picture,&memory,&image->exception);
 
 #if defined(MAGICKCORE_WEBPMUX_DELEGATE)
-  if ((image_info->adjoin != MagickFalse) &&
+  if ((GetImageListLength(image) > 1) &&
       (GetPreviousImageInList(image) == (Image *) NULL) &&
       (GetNextImageInList(image) != (Image *) NULL) &&
       (image->iterations != 1))


### PR DESCRIPTION
Hi.

I fixed the webp coder (encoder part) to support an animate webp image.
Currently, image_info->adjoin is always MagickFlase because 'image_info' is set at "RegisterWEBPImage" function which initialize adjoin field as MagickFalse.
So, I change to check the number of images not adjoin field value.

Sincerely.
Joonsung Kim.