### PR TITLE
Backport fix for CVE-2021-20244

### DIFF
--- a/magick/visual-effects.c
+++ b/magick/visual-effects.c
@@ -1103,11 +1103,11 @@ MagickExport Image *ImplodeImage(const Image *image,const double amount,
           */
           factor=1.0;
           if (distance > 0.0)
-            factor=pow(sin((double) (MagickPI*sqrt((double) distance)/
-              radius/2)),-amount);
+            factor=pow(sin((double) (MagickPI*sqrt((double) distance)*
+              PerceptibleReciprocal(radius)/2)),-amount);
           status=InterpolateMagickPixelPacket(image,image_view,
-            UndefinedInterpolatePixel,(double) (factor*delta.x/scale.x+
-            center.x),(double) (factor*delta.y/scale.y+center.y),&pixel,
+            UndefinedInterpolatePixel,(double) (factor*delta.x*PerceptibleReciprocal(scale.x)+
+            center.x),(double) (factor*delta.y*PerceptibleReciprocal(scale.y)+center.y),&pixel,
             exception);
           if (status == MagickFalse)
             break;


### PR DESCRIPTION
I noticed that the fix for [CVE-2021-20244](https://nvd.nist.gov/vuln/detail/CVE-2021-20244) in https://github.com/ImageMagick/ImageMagick/commit/329dd528ab79531d884c0ba131e97d43f872ab5d wasn't backported to IM6.

Please note that I have very little clue of C programming. It compiles though and I think the fix is not very complex.