### PR TITLE
fix memory corruption in ConcatenateStringInfo

### DIFF
--- a/magick/string.c
+++ b/magick/string.c
@@ -564,7 +564,6 @@ MagickExport void ConcatenateStringInfo(StringInfo *string_info,
   length+=source->length;
   if (~length < MagickPathExtent)
     ThrowFatalException(ResourceLimitFatalError,"MemoryAllocationFailed");
-  string_info->length=length;
   if (string_info->datum == (unsigned char *) NULL)
     string_info->datum=(unsigned char *) AcquireQuantumMemory(length+
       MagickPathExtent,sizeof(*string_info->datum));
@@ -574,7 +573,8 @@ MagickExport void ConcatenateStringInfo(StringInfo *string_info,
       sizeof(*string_info->datum));
   if (string_info->datum == (unsigned char *) NULL)
     ThrowFatalException(ResourceLimitFatalError,"MemoryAllocationFailed");
-  (void) memcpy(string_info->datum+length,source->datum,source->length);
+  (void) memcpy(string_info->datum+string_info->length,source->datum,source->length);
+  string_info->length=length;
 }
 
 /*


### PR DESCRIPTION
Same as https://github.com/ImageMagick/ImageMagick/pull/3858

