### PR TITLE
Fix build with -Werror

### DIFF
--- a/magick/log.c
+++ b/magick/log.c
@@ -394,7 +394,7 @@ MagickExport void CloseMagickLog(void)
 %      const char *GetLogEventMask(void)
 %
 */
-MagickExport const LogEventType GetLogEventMask(void)
+MagickExport LogEventType GetLogEventMask(void)
 {
   ExceptionInfo
     *exception;
@@ -515,7 +515,7 @@ static int LogInfoCompare(const void *x,const void *y)
 }
 #endif
 
-MagickExport const LogInfo **GetLogInfoList(const char *pattern,
+MagickExport LogInfo **GetLogInfoList(const char *pattern,
   size_t *number_preferences,ExceptionInfo *exception)
 {
   const LogInfo
@@ -674,7 +674,7 @@ MagickExport char **GetLogList(const char *pattern,
 %      const char *GetLogName(void)
 %
 */
-MagickExport const char *GetLogName(void)
+MagickExport char *GetLogName(void)
 {
   return(log_name);
 }
@@ -1930,7 +1930,7 @@ MagickExport void SetLogMethod(MagickLogMethod method)
 %    o name: Specifies the new client name.
 %
 */
-MagickExport const char *SetLogName(const char *name)
+MagickExport char *SetLogName(const char *name)
 {
   if ((name != (char *) NULL) && (*name != '\0'))
     (void) CopyMagickString(log_name,name,MaxTextExtent);

--- a/magick/log.h
+++ b/magick/log.h
@@ -66,14 +66,14 @@ typedef void
 extern MagickExport char
   **GetLogList(const char *,size_t *,ExceptionInfo *);
 
-extern MagickExport const char
+extern MagickExport char
   *GetLogName(void) magick_attribute((__pure__)),
   *SetLogName(const char *);
 
-extern MagickExport const LogEventType
+extern MagickExport LogEventType
   GetLogEventMask(void) magick_attribute((__pure__));
 
-extern MagickExport const LogInfo
+extern MagickExport LogInfo
   **GetLogInfoList(const char *,size_t *,ExceptionInfo *);
 
 extern MagickExport LogEventType

--- a/magick/pixel-accessor.h
+++ b/magick/pixel-accessor.h
@@ -103,12 +103,12 @@ extern "C" {
 #define SetPixelYellow(pixel,value) ((pixel)->blue=(Quantum) (value))
 #define SetPixelY(pixel,value) ((pixel)->red=(Quantum) (value))
 
-static inline const MagickRealType AbsolutePixelValue(const MagickRealType x)
+static inline MagickRealType AbsolutePixelValue(const MagickRealType x)
 {
   return(x < 0.0f ? -x : x);
 }
 
-static inline const Quantum ClampPixel(const MagickRealType value)
+static inline Quantum ClampPixel(const MagickRealType value)
 { 
   if (value < 0.0f)
     return((Quantum) 0); 
@@ -121,7 +121,7 @@ static inline const Quantum ClampPixel(const MagickRealType value)
 #endif
 }
 
-static inline const double PerceptibleReciprocal(const double x)
+static inline double PerceptibleReciprocal(const double x)
 { 
   double
     sign;
@@ -135,7 +135,7 @@ static inline const double PerceptibleReciprocal(const double x)
   return(sign/MagickEpsilon);
 }   
 
-static inline const MagickRealType GetPixelLuma(
+static inline MagickRealType GetPixelLuma(
   const Image *magick_restrict image,const PixelPacket *magick_restrict pixel)
 {
   MagickRealType
@@ -147,7 +147,7 @@ static inline const MagickRealType GetPixelLuma(
   return(intensity);
 }
 
-static inline const MagickRealType GetPixelLuminance(
+static inline MagickRealType GetPixelLuminance(
   const Image *magick_restrict image,const PixelPacket *magick_restrict pixel)
 {
   MagickRealType
@@ -165,7 +165,7 @@ static inline const MagickRealType GetPixelLuminance(
   return(intensity);
 }
 
-static inline const MagickBooleanType IsPixelAtDepth(const Quantum pixel,
+static inline MagickBooleanType IsPixelAtDepth(const Quantum pixel,
   const QuantumAny range)
 {
   Quantum
@@ -183,7 +183,7 @@ static inline const MagickBooleanType IsPixelAtDepth(const Quantum pixel,
   return(pixel == quantum ? MagickTrue : MagickFalse);
 }
 
-static inline const MagickBooleanType IsPixelGray(const PixelPacket *pixel)
+static inline MagickBooleanType IsPixelGray(const PixelPacket *pixel)
 {
   MagickRealType
     green_blue,
@@ -197,7 +197,7 @@ static inline const MagickBooleanType IsPixelGray(const PixelPacket *pixel)
   return(MagickFalse);
 }
 
-static inline const MagickBooleanType IsPixelMonochrome(
+static inline MagickBooleanType IsPixelMonochrome(
   const PixelPacket *pixel)
 {
   MagickRealType
@@ -217,7 +217,7 @@ static inline const MagickBooleanType IsPixelMonochrome(
   return(MagickFalse);
 }
 
-static inline const Quantum PixelPacketIntensity(const PixelPacket *pixel)
+static inline Quantum PixelPacketIntensity(const PixelPacket *pixel)
 {
   MagickRealType
     intensity;


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick6/pulls) open
- [X] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

We have an error building 'lebiniou' on FreeBSD (and maybe other platform). 'lebiniou' uses -Werror flag and raises errors in ImageMagick6:

`error: 'const' type qualifier on return type has no effect [-Werror,-Wignored-qualifiers]`

Removing theses `const` allows building 'lebiniou' (and other software using these files with -Werror flag).

FreeBSD patch: https://github.com/freebsd/freebsd-ports/commit/06ba562579f8b627b7bb8fdafc8a3ad422577648

cc @oliv3

<!-- Thanks for contributing to ImageMagick! -->
