### PR TITLE
Test with mingw-w64 using MSYS2 CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         compiler: [ gcc, clang ]
 
@@ -106,3 +106,31 @@ jobs:
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
         cd ImageMagick6-Windows\VisualMagick
         msbuild VisualStaticMTD.sln /m /t:Rebuild /p:Configuration=Release,Platform=x64
+
+  build_msys2:
+    name: Build MSYS2
+    runs-on: windows-latest
+
+    steps:
+    - name: Prepare git
+      run: git config --global core.autocrlf false
+
+    - uses: actions/checkout@v3
+
+    - uses: actions/checkout@v3
+      with:
+        repository: ImageMagick/ImageMagick6-Windows
+        path: ImageMagick6-Windows
+        ref: refs/heads/main
+
+    - uses: msys2/setup-msys2@v2
+      with:
+        install: mingw-w64-x86_64-toolchain base-devel binutils
+        update: true
+
+    - name: Building ImageMagick
+      run: cd ImageMagick6-Windows && makepkg-mingw --noconfirm --syncdeps
+      env:
+        MINGW_ARCH: mingw64
+        PKGEXT: ".pkg.tar.xz"
+      shell: msys2 {0}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick6/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
Adds CI for mingw-w64 using the awesome [msys2 action](https://github.com/msys2/setup-msys2). I adapted the build configuration and patches from upstream msys2 [mingw-w64-imagemagick](https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-imagemagick).
