### PR TITLE
Fix various redefinition warnings in mingw

### DIFF
--- a/coders/djvu.c
+++ b/coders/djvu.c
@@ -314,9 +314,6 @@ process_message(ddjvu_message_t *message)
 }
 #endif
 
-
-#define RGB 1
-
 /*
  * DjVu advertised readiness to provide bitmap: So get it!
  * we use the RGB format!
@@ -460,6 +457,9 @@ get_page_image(LoadContext *lc, ddjvu_page_t *page, int x, int y, int w, int h, 
 #if defined(MAGICKCORE_DJVU_DELEGATE)
 
 #if 0
+
+#define RGB 1
+
 static int
 get_page_line(LoadContext *lc, int row, QuantumInfo* quantum_info)
 {

--- a/coders/icon.c
+++ b/coders/icon.c
@@ -70,11 +70,7 @@
 /*
   Define declarations.
 */
-#if !defined(MAGICKCORE_WINDOWS_SUPPORT) || defined(__MINGW32__)
-#define BI_RGB  0
-#define BI_RLE8  1
-#define BI_BITFIELDS  3
-#endif
+#define IconRgbCompression (size_t) 0
 #define MaxIcons  1024
 
 /*
@@ -1033,7 +1029,7 @@ static MagickBooleanType WriteICONImage(const ImageInfo *image_info,
       (void) TransformImageColorspace(image,sRGBColorspace);
         icon_info.file_size=14+12+28;
         icon_info.offset_bits=icon_info.file_size;
-        icon_info.compression=BI_RGB;
+        icon_info.compression=IconRgbCompression;
         if ((next->storage_class != DirectClass) && (next->colors > 256))
           (void) SetImageStorageClass(next,DirectClass);
         if (next->storage_class == DirectClass)
@@ -1043,7 +1039,7 @@ static MagickBooleanType WriteICONImage(const ImageInfo *image_info,
             */
             icon_info.number_colors=0;
             icon_info.bits_per_pixel=32;
-            icon_info.compression=(size_t) BI_RGB;
+            icon_info.compression=IconRgbCompression;
           }
         else
           {
@@ -1065,7 +1061,7 @@ static MagickBooleanType WriteICONImage(const ImageInfo *image_info,
                 (void) SetImageStorageClass(next,DirectClass);
                 icon_info.number_colors=0;
                 icon_info.bits_per_pixel=(unsigned short) 24;
-                icon_info.compression=(size_t) BI_RGB;
+                icon_info.compression=IconRgbCompression;
               }
             else
               {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick6/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
These fix various redefinition warnings in mingw. The patches are imported from ImageMagick 7 repository without any significant changes. The changes are local to the corresponding functions.