### PR TITLE
coders: Enable opening https files in mingw

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -258,9 +258,10 @@ bin_PROGRAMS = $(am__EXEEXT_1)
 TESTS = $(TESTS_TESTS) $(am__EXEEXT_5)
 XFAIL_TESTS = $(am__EXEEXT_6) $(am__EXEEXT_6)
 check_PROGRAMS = $(am__EXEEXT_2) $(am__EXEEXT_4)
-@WIN32_NATIVE_BUILD_TRUE@am__append_1 = -lws2_32
-@MAGICKCORE_ZERO_CONFIGURATION_SUPPORT_TRUE@am__append_2 = magick/threshold-map.h
+@WIN32_NATIVE_BUILD_TRUE@am__append_1 = -lurlmon
+@WIN32_NATIVE_BUILD_TRUE@am__append_2 = -lws2_32
 @MAGICKCORE_ZERO_CONFIGURATION_SUPPORT_TRUE@am__append_3 = magick/threshold-map.h
+@MAGICKCORE_ZERO_CONFIGURATION_SUPPORT_TRUE@am__append_4 = magick/threshold-map.h
 subdir = .
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/m4/ac_func_fseeko.m4 \
@@ -1268,7 +1269,7 @@ coders_uil_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 @WITH_MODULES_TRUE@am_coders_uil_la_rpath = -rpath $(codersdir)
 coders_url_la_DEPENDENCIES = $(MAGICKCORE_LIBS) $(am__DEPENDENCIES_1) \
 	$(am__DEPENDENCIES_1) $(am__DEPENDENCIES_1) \
-	$(am__DEPENDENCIES_1)
+	$(am__DEPENDENCIES_1) $(am__DEPENDENCIES_1)
 am_coders_url_la_OBJECTS = coders/url_la-url.lo
 coders_url_la_OBJECTS = $(am_coders_url_la_OBJECTS)
 coders_url_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
@@ -3398,7 +3399,7 @@ MODULECOMMONCPPFLAGS = $(AM_CPPFLAGS)
 DISTCHECK_CONFIGURE_FLAGS = $(DISTCHECK_CONFIG_FLAGS)
 DISTCLEANFILES = _configs.sed magick/magick-baseconfig.h
 CLEANFILES = $(WAND_CLEANFILES) $(MAGICKPP_CLEANFILES) \
-	$(UTILITIES_CLEANFILES) $(TESTS_CLEANFILES) $(am__append_3)
+	$(UTILITIES_CLEANFILES) $(TESTS_CLEANFILES) $(am__append_4)
 
 # Binary scripts
 bin_SCRIPTS = \
@@ -4503,7 +4504,8 @@ coders_uil_la_LIBADD = $(MAGICKCORE_LIBS)
 coders_url_la_SOURCES = coders/url.c
 coders_url_la_CPPFLAGS = $(MAGICK_CODER_CPPFLAGS)
 coders_url_la_LDFLAGS = $(MODULECOMMONFLAGS)
-coders_url_la_LIBADD = $(MAGICKCORE_LIBS) $(XML_LIBS) $(LZMA_LIBS) $(ZLIB_LIBS) $(MATH_LIBS)
+coders_url_la_LIBADD = $(MAGICKCORE_LIBS) $(XML_LIBS) $(LZMA_LIBS) \
+	$(ZLIB_LIBS) $(MATH_LIBS) $(am__append_1)
 
 # UYVY coder module
 coders_uyvy_la_SOURCES = coders/uyvy.c
@@ -4646,11 +4648,11 @@ MAGICKCORE_LIBS = magick/libMagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX
 @WITH_MODULES_FALSE@magick_libMagickCore_@MAGICK_MAJOR_VERSION@_@MAGICK_ABI_SUFFIX@_la_SOURCES = $(MAGICK_BASE_SRCS) $(MAGICK_PLATFORM_SRCS) $(MAGICK_CODER_SRCS) $(MAGICK_FILTER_SRCS)
 @WITH_MODULES_TRUE@magick_libMagickCore_@MAGICK_MAJOR_VERSION@_@MAGICK_ABI_SUFFIX@_la_SOURCES = $(MAGICK_BASE_SRCS) $(MAGICK_PLATFORM_SRCS)
 @WITH_MODULES_FALSE@magick_libMagickCore_@MAGICK_MAJOR_VERSION@_@MAGICK_ABI_SUFFIX@_la_LIBADD =  \
-@WITH_MODULES_FALSE@	$(MAGICK_DEP_LIBS) $(am__append_1)
+@WITH_MODULES_FALSE@	$(MAGICK_DEP_LIBS) $(am__append_2)
 @WITH_MODULES_TRUE@magick_libMagickCore_@MAGICK_MAJOR_VERSION@_@MAGICK_ABI_SUFFIX@_la_LIBADD =  \
-@WITH_MODULES_TRUE@	$(MAGICK_DEP_LIBS) $(am__append_1)
+@WITH_MODULES_TRUE@	$(MAGICK_DEP_LIBS) $(am__append_2)
 nodist_magick_libMagickCore_@MAGICK_MAJOR_VERSION@_@MAGICK_ABI_SUFFIX@_la_SOURCES =  \
-	$(am__append_2)
+	$(am__append_3)
 magick_libMagickCore_@MAGICK_MAJOR_VERSION@_@MAGICK_ABI_SUFFIX@_la_CPPFLAGS = $(AM_CPPFLAGS) $(LIBRARY_EXTRA_CPPFLAGS)
 @HAVE_LD_VERSION_SCRIPT_FALSE@magick_libMagickCore_@MAGICK_MAJOR_VERSION@_@MAGICK_ABI_SUFFIX@_la_LDFLAGS_VERSION = -export-symbols-regex ".*"
 @HAVE_LD_VERSION_SCRIPT_TRUE@magick_libMagickCore_@MAGICK_MAJOR_VERSION@_@MAGICK_ABI_SUFFIX@_la_LDFLAGS_VERSION = -Wl,--version-script=$(top_srcdir)/magick/libMagickCore.map

--- a/coders/Makefile.am
+++ b/coders/Makefile.am
@@ -1007,6 +1007,9 @@ coders_url_la_SOURCES      = coders/url.c
 coders_url_la_CPPFLAGS     = $(MAGICK_CODER_CPPFLAGS)
 coders_url_la_LDFLAGS      = $(MODULECOMMONFLAGS)
 coders_url_la_LIBADD       = $(MAGICKCORE_LIBS) $(XML_LIBS) $(LZMA_LIBS) $(ZLIB_LIBS) $(MATH_LIBS)
+if WIN32_NATIVE_BUILD
+coders_url_la_LIBADD      += -lurlmon
+endif
 
 # UYVY coder module
 coders_uyvy_la_SOURCES     = coders/uyvy.c

--- a/coders/url.c
+++ b/coders/url.c
@@ -74,8 +74,7 @@
 #  include <libxml/nanohttp.h>
 #endif
 #endif
-#if defined(MAGICKCORE_WINDOWS_SUPPORT) && \
-    !defined(__MINGW32__)
+#if defined(MAGICKCORE_WINDOWS_SUPPORT)
 #  include <urlmon.h>
 #  pragma comment(lib, "urlmon.lib")
 #endif
@@ -159,7 +158,7 @@ static Image *ReadURLImage(const ImageInfo *image_info,ExceptionInfo *exception)
   image=AcquireImage(image_info);
   read_info=CloneImageInfo(image_info);
   SetImageInfoBlob(read_info,(void *) NULL,0);
-#if !defined(MAGICKCORE_WINDOWS_SUPPORT) || defined(__MINGW32__)
+#if !defined(MAGICKCORE_WINDOWS_SUPPORT)
   if (LocaleCompare(read_info->magick,"https") == 0)
     {
       MagickBooleanType
@@ -213,7 +212,7 @@ static Image *ReadURLImage(const ImageInfo *image_info,ExceptionInfo *exception)
   (void) ConcatenateMagickString(filename,":",MaxTextExtent);
   LocaleLower(filename);
   (void) ConcatenateMagickString(filename,image_info->filename,MaxTextExtent);
-#if defined(MAGICKCORE_WINDOWS_SUPPORT) && !defined(__MINGW32__)
+#if defined(MAGICKCORE_WINDOWS_SUPPORT)
   (void) fclose(file);
   if (URLDownloadToFile(NULL,filename,read_info->filename,0,NULL) != S_OK)
     {
@@ -322,8 +321,7 @@ ModuleExport size_t RegisterURLImage(void)
     *entry;
 
   entry=SetMagickInfo("HTTP");
-#if (defined(MAGICKCORE_WINDOWS_SUPPORT) && \
-    !defined(__MINGW32__)) || \
+#if defined(MAGICKCORE_WINDOWS_SUPPORT) || \
     (defined(MAGICKCORE_XML_DELEGATE) && defined(LIBXML_HTTP_ENABLED))
   entry->decoder=(DecodeImageHandler *) ReadURLImage;
 #endif
@@ -338,8 +336,7 @@ ModuleExport size_t RegisterURLImage(void)
   entry->format_type=ImplicitFormatType;
   (void) RegisterMagickInfo(entry);
   entry=SetMagickInfo("FTP");
-#if (defined(MAGICKCORE_WINDOWS_SUPPORT) && \
-    !defined(__MINGW32__)) || \
+#if defined(MAGICKCORE_WINDOWS_SUPPORT) || \
     (defined(MAGICKCORE_XML_DELEGATE) && defined(LIBXML_FTP_ENABLED))
   entry->decoder=(DecodeImageHandler *) ReadURLImage;
 #endif


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick6/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

This feature was enabled for Windows platform but disabled for mingw toolchain in 97196e70a7b3274ef45ada1a01f39637f9f829bf commit.

This fixes the following error with magick command in mingw:

```
$ identify https://imagemagick.org/image/wizard.png
identify.exe: unable to create temporary file '//imagemagick.org/image/wizard.png': No such file or directory @ error/delegate.c/InvokeDelegate/1950.
```
