### PR TITLE
Fix the max memory request initial value in memory.c and comparison in jpeg.c

### DIFF
--- a/coders/jpeg.c
+++ b/coders/jpeg.c
@@ -1208,7 +1208,7 @@ static Image *ReadJPEGImage_(const ImageInfo *image_info,
     }
   jpeg_info->client_data=(void *) client_info;
   jpeg_create_decompress(jpeg_info);
-  if (GetMaxMemoryRequest() != ~0UL)
+  if (GetMaxMemoryRequest() != (size_t) MAGICK_SSIZE_MAX)
     jpeg_info->mem->max_memory_to_use=(long) GetMaxMemoryRequest();
   jpeg_progress.progress_monitor=(void (*)(j_common_ptr)) JPEGProgressHandler;
   jpeg_info->progress=(&jpeg_progress);

--- a/coders/jpeg.c
+++ b/coders/jpeg.c
@@ -84,6 +84,7 @@
 #include "magick/token.h"
 #include "magick/utility.h"
 #include "magick/xml-tree.h"
+#include <limits.h>
 #include <setjmp.h>
 #if defined(MAGICKCORE_JPEG_DELEGATE)
 #define JPEG_INTERNAL_OPTIONS
@@ -1150,6 +1151,7 @@ static Image *ReadJPEGImage_(const ImageInfo *image_info,
     *p;
 
   size_t
+    max_memory_to_use,
     units;
 
   ssize_t
@@ -1208,8 +1210,9 @@ static Image *ReadJPEGImage_(const ImageInfo *image_info,
     }
   jpeg_info->client_data=(void *) client_info;
   jpeg_create_decompress(jpeg_info);
-  if (GetMaxMemoryRequest() != (size_t) MAGICK_SSIZE_MAX)
-    jpeg_info->mem->max_memory_to_use=(long) GetMaxMemoryRequest();
+  max_memory_to_use=GetMaxMemoryRequest();
+  if (max_memory_to_use < (size_t) LONG_MAX)
+    jpeg_info->mem->max_memory_to_use=(long) max_memory_to_use;
   jpeg_progress.progress_monitor=(void (*)(j_common_ptr)) JPEGProgressHandler;
   jpeg_info->progress=(&jpeg_progress);
   JPEGSourceManager(jpeg_info,image);

--- a/magick/memory.c
+++ b/magick/memory.c
@@ -1051,7 +1051,7 @@ MagickExport size_t GetMaxMemoryRequest(void)
       char
         *value;
 
-      max_memory_request=(size_t) MagickULLConstant(~0);
+      max_memory_request=(size_t) MAGICK_SSIZE_MAX;
       value=GetPolicyValue("system:max-memory-request");
       if (value != (char *) NULL)
         {
@@ -1063,7 +1063,7 @@ MagickExport size_t GetMaxMemoryRequest(void)
           value=DestroyString(value);
         }
     }
-  return(MagickMin(max_memory_request,MAGICK_SSIZE_MAX));
+  return(MagickMin(max_memory_request,(size_t) MAGICK_SSIZE_MAX));
 }
 
 /*


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick6/pulls) open
- [X] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
Avoids the error "Backing store not supported" when converting some jpeg (progressive in my case) on Windows (x86_64-w64-mingw32-gcc).

First, the initial value of max_memory_request in GetMaxMemoryRequest is inconsistent with the MagickMin return value. This was already fixed on ImageMagick 7:
 - ImageMagick/ImageMagick@2f442f7f05d02dc4d0a0399c32c07c1f47fc3841
 - ImageMagick/ImageMagick@6ccb83b8ad7e4532547ca738774a1aa74ff3b076
 - ImageMagick/ImageMagick@28637d210be357dc11e59776864c3dc2ac52a927

I have not understood why MAGICK_SSIZE_MAX is preferred over MAGICK_SIZE_MAX.

Second, the comparison in coders/jpeg.c always returned true because neither ~0ULL nor MAGICK_SSIZE_MAX equals ~0UL on Windows when compiled with MinGW-w64, resulting in an invalid max memory size configuration in the jpeg library.
