### PR TITLE
- simple backport of https://github.com/ImageMagick/ImageMagick/commi…

### DIFF
--- a/coders/png.c
+++ b/coders/png.c
@@ -3879,6 +3879,7 @@ static Image *ReadOnePNGImage(MngInfo *mng_info,
 
                 (void) FormatLocaleString(key,MaxTextExtent,"%s",text[i].key);
                 if ((LocaleCompare(key,"version") == 0) ||
+                    (LocaleCompare(key,"profile") == 0) ||
                     (LocaleCompare(key,"width") == 0))
                   (void) FormatLocaleString(key,MagickPathExtent,"png:%s",
                     text[i].key);


### PR DESCRIPTION
Simple backport of this fix https://github.com/ImageMagick/ImageMagick/commit/05673e63c919e61ffa1107804d1138c46547a475?diff=split

to fix cve-2022-44267 and cve-2022-44268 on ImageMagick6

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick6/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
The last version of Imagemagick6 is vulnerable to cve-2022-44268 (and cve-2022-44267 but I have not tested it).
Even with the policy that forbid path to /etc/* (or I missed something)
Anyway, I've just backported the test for the "profile" string in the png coder available here: https://github.com/ImageMagick/ImageMagick/commit/05673e63c919e61ffa1107804d1138c46547a475?diff=split

ref: https://www.cve.org/CVERecord?id=CVE-2022-44268
