### PR TITLE
fix type cast

### DIFF
--- a/PerlMagick/quantum/quantum.xs.in
+++ b/PerlMagick/quantum/quantum.xs.in
@@ -10843,7 +10843,7 @@ Mogrify(ref,...)
             channel=(ChannelType) argument_list[1].integer_reference;
           method=UndefinedMorphology;
           if (attribute_flag[2] != 0)
-            method=(MorphologyMethod)) argument_list[2].integer_reference;
+            method=(MorphologyMethod) argument_list[2].integer_reference;
           iterations=1;
           if (attribute_flag[3] != 0)
             iterations=argument_list[3].integer_reference;


### PR DESCRIPTION
Version 7.1.1.16 is OK
Version  6.9.12-93 was OK
Version  6.9.12-94 is broken

Trivial typo fix 
See 0304430e4c91fe0af11365bb46c15b182c2fced6