### PR TITLE
fix error: 'libraw_data_t' has no member named 'rawparams'

### DIFF
--- a/coders/dng.c
+++ b/coders/dng.c
@@ -327,7 +327,7 @@ static void SetLibRawParams(const ImageInfo *image_info,Image *image,
   const char
     *option;
 
-#if LIBRAW_COMPILE_CHECK_VERSION_NOTLESS(0,20)
+#if LIBRAW_COMPILE_CHECK_VERSION_NOTLESS(0,21)
   raw_info->rawparams.max_raw_memory_mb=8192;
   option=GetImageOption(image_info,"dng:max-raw-memory");
   if (option != (const char *) NULL)


### PR DESCRIPTION


Build failure on Fedora 37 and RHEL 9 (libRaw 0.20.2)

Also on https://github.com/ImageMagick/ImageMagick/pull/6989