### PR TITLE
delete stray incorrect Unicode characters

### DIFF
--- a/configure
+++ b/configure
@@ -31537,8 +31537,8 @@ else
 printf "%s\n" "yes" >&6; }
 	have_jpeg=yes
 fi
-￼   CFLAGS="$CFLAGS $JPEG_CFLAGS"
-￼   LIBS="$LIBS $JPEG_LIBS"
+    CFLAGS="$CFLAGS $JPEG_CFLAGS"
+    LIBS="$LIBS $JPEG_LIBS"
 
     ac_fn_c_check_header_compile "$LINENO" "jconfig.h" "ac_cv_header_jconfig_h" "$ac_includes_default"
 if test "x$ac_cv_header_jconfig_h" = xyes


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick6/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

See below for output of running `configure`. I saw the unusual `command not found` errors. I looked at the lines indicated and discovered some odd Unicode characters. I replaced the octal characters `\357\277\274` (in hex: `\xEF\xBF\xBC`), with spaces in my local copy of `configure`, and ran it again. This seemed to resolve the problem.

From my limited exploration of where these characters came from, it looks like they were introduced in commit [119eb49](https://github.com/ImageMagick/ImageMagick6/commit/119eb49c9fb31c08b2fb260b124b593fca436e85) into lines 31599 and 31600 (as they were back then).

@urban-warrior 

```
-------------------------------------------------------------
checking for JBIG...
checking for jbig.h... yes
checking for jbg_dec_init in -ljbig... yes
checking if JBIG package is complete... yes
-------------------------------------------------------------
checking for JPEG...
checking for libjpeg >= 2.0.0... yes
./configure: line 31540: $'\357\277\274': command not found
./configure: line 31541: $'\357\277\274': command not found
checking for jconfig.h... yes
checking for jerror.h... yes
checking for jmorecfg.h... yes
checking for jpeglib.h... yes
checking for jpeg_read_header in -ljpeg... yes
checking if JPEG package is complete... yes
-------------------------------------------------------------
checking for lcms2 >= 2.0.0... yes

checking for lcms2/lcms2.h... no
-------------------------------------------------------------

```

