### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <img align="center" src="https://legacy.imagemagick.org/image/wizard.png" alt="ImageMagick logo" width="265" height="353"/>
 </p>
 
-[ImageMagick®](https://legacy.imagemagick.org/) is a free and [open-source](https://legacy.imagemagick.org/script/license.php) oftware suite, used for editing and manipulating digital images. It can be used to create, edit, compose, or convert bitmap images, and supports a wide range of file [formats](https://legacy.imagemagick.org/script/formats.php), including JPEG, PNG, GIF, TIFF, and PDF.
+[ImageMagick®](https://legacy.imagemagick.org/) is a free and [open-source](https://legacy.imagemagick.org/script/license.php) software suite, used for editing and manipulating digital images. It can be used to create, edit, compose, or convert bitmap images, and supports a wide range of file [formats](https://legacy.imagemagick.org/script/formats.php), including JPEG, PNG, GIF, TIFF, and PDF.
 
 ## What is ImageMagick?
 


### PR DESCRIPTION
I found a typo in the README.md

On the opening sentence it reads, "ImageMagick® is a free and open-source _oftware_ suite..." I'm assuming it should be, "**s**oftware suite..."