### PR TITLE
Fix missing 'tiff:endian' image property

### DIFF
--- a/coders/tiff.c
+++ b/coders/tiff.c
@@ -1341,7 +1341,6 @@ static Image *ReadTIFFImage(const ImageInfo *image_info,
     image->endian=MSBEndian;
     if (endian == FILLORDER_LSB2MSB)
       image->endian=LSBEndian;
-#if defined(MAGICKCORE_HAVE_TIFFISBIGENDIAN)
     if (TIFFIsBigEndian(tiff) == 0)
       {
         (void) SetImageProperty(image,"tiff:endian","lsb");
@@ -1352,7 +1351,6 @@ static Image *ReadTIFFImage(const ImageInfo *image_info,
         (void) SetImageProperty(image,"tiff:endian","msb");
         image->endian=MSBEndian;
       }
-#endif
     if ((photometric == PHOTOMETRIC_MINISBLACK) ||
         (photometric == PHOTOMETRIC_MINISWHITE))
       image->colorspace=GRAYColorspace;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick6/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Fix missing 'tiff:endian' image property

`HAVE_TIFFISBIGENDIAN` macro was removed in
d0b6b4815e0c2ac77ea6e5dc14f67f425c0cfc47, but the macro was still used for a conditional block in `tiff.c` responsible for setting the `tiff:endian` image property. The macro was never set, essentially disabling this functionality.

We can safely remove the conditional compilation and assume `TIFFIsBigEndian` is always available: we require at least libtiff 4.0.0, while `TIFFIsBigEndian` was added in 3.7.0.

<!-- Thanks for contributing to ImageMagick! -->
