### PR TITLE
Fix memory corrution in ClonePixelWands

### DIFF
--- a/wand/pixel-wand.c
+++ b/wand/pixel-wand.c
@@ -198,7 +198,7 @@ WandExport PixelWand **ClonePixelWands(const PixelWand **wands,
   PixelWand
     **clone_wands;
 
-  clone_wands=(PixelWand **) AcquireCriticalMemory((size_t) number_wands&
+  clone_wands=(PixelWand **) AcquireCriticalMemory((size_t) number_wands*
     sizeof(*clone_wands));
   for (i=0; i < (ssize_t) number_wands; i++)
     clone_wands[i]=ClonePixelWand(wands[i]);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick6/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
Size of `clone_wands` shoud be equal to `number_wands` times `sizeof(*clone_wands)`. If we use `&` we can't recieve more than `sizeof(PixelWand*)` (some constant). So this code will `ClonePixelWand` into some dirty memory

<!-- Thanks for contributing to ImageMagick! -->
