### PR TITLE
Backport DNG grayscale support from IM7

### DIFF
--- a/coders/dng.c
+++ b/coders/dng.c
@@ -545,7 +545,7 @@ static Image *ReadDNGImage(const ImageInfo *image_info,ExceptionInfo *exception)
     if ((errcode != LIBRAW_SUCCESS) || 
         (raw_image == (libraw_processed_image_t *) NULL) ||
         (raw_image->type != LIBRAW_IMAGE_BITMAP) || (raw_image->bits != 16) ||
-        (raw_image->colors < 3) || (raw_image->colors > 4))
+        (raw_image->colors < 1) || (raw_image->colors > 4))
       {
         if (raw_image != (libraw_processed_image_t *) NULL)
           libraw_dcraw_clear_mem(raw_image);
@@ -588,9 +588,12 @@ static Image *ReadDNGImage(const ImageInfo *image_info,ExceptionInfo *exception)
       for (x=0; x < (ssize_t) image->columns; x++)
       {
         SetPixelRed(q,ScaleShortToQuantum(*p++));
-        SetPixelGreen(q,ScaleShortToQuantum(*p++));
-        SetPixelBlue(q,ScaleShortToQuantum(*p++));
-        if (raw_image->colors > 3)
+        if (raw_image->colors > 2)
+          {
+            SetPixelGreen(q,ScaleShortToQuantum(*p++));
+            SetPixelBlue(q,ScaleShortToQuantum(*p++));
+          }
+        if ((raw_image->colors == 2) || (raw_image->colors > 3))
           SetPixelAlpha(q,ScaleShortToQuantum(*p++));
         q++;
       }


### PR DESCRIPTION
Backport https://github.com/ImageMagick/ImageMagick/commit/cffd9de73622c540b0e0e889c32445cef20c5a1c to IM6.

Please double check `coders/dng.c:560`. IM7 uses `GrayscaleType : GrayscaleAlphaType` and IM6 `GrayscaleMatteType`, but this block was previously never reached. Tried to keep the changes to minimum and used MatteType, which does seem to work.

Tested w/
```bash
$ wget https://img.photographyblog.com/reviews/leica_m_monochrom_typ_246/photos/leica_m_monochrom_typ_246_01.dng
```

Upstream:
```bash
$ ./utilities/convert ~/leica_m_monochrom_typ_246_01.dng test.png
lt-convert: No error `/home/vagrant/leica_m_monochrom_typ_246_01.dng' @ error/dng.c/ReadDNGImage/552.
lt-convert: NoImagesDefined `test.png' @ error/convert.c/ConvertImageCommand/3234.
```

This PR:
```bash
$ ./utilities/convert ~/leica_m_monochrom_typ_246_01.dng test.png
$ file test.png
test.png: PNG image data, 5984 x 4000, 16-bit/color RGB, non-interlaced
```
